### PR TITLE
#137 - Add support of `false` return type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.lo
 *.la
 *.profraw
+*.dep
 
 .deps
 .libs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added - xxxx-xx-xx
+- Added support for `false` return type [#137](https://github.com/phalcon/php-zephir-parser/issues/137)
 
 ## [1.4.2] - 2021-12-11
 ### Added

--- a/package.xml
+++ b/package.xml
@@ -108,6 +108,7 @@
 
                     <dir name="return-types">
                         <file name="false.phpt" role="test"/>
+                        <file name="float.phpt" role="test"/>
                         <file name="int.phpt" role="test"/>
                         <file name="mixed.phpt" role="test"/>
                     </dir>

--- a/package.xml
+++ b/package.xml
@@ -107,6 +107,7 @@
                     </dir>
 
                     <dir name="return-types">
+                        <file name="false.phpt" role="test"/>
                         <file name="int.phpt" role="test"/>
                         <file name="mixed.phpt" role="test"/>
                     </dir>

--- a/parser/parser.h
+++ b/parser/parser.h
@@ -598,6 +598,10 @@ static void xx_ret_type(zval *ret, int type)
 			parser_get_string(ret, "this");
             return;
 
+        case XX_T_TYPE_FALSE:
+        	parser_get_string(ret, "false");
+			return;
+
 		default:
 			fprintf(stderr, "unknown type?\n");
 	}

--- a/parser/scanner.h
+++ b/parser/scanner.h
@@ -47,6 +47,7 @@
 #define XX_T_TYPE_NULL 334
 #define XX_T_TYPE_THIS 335
 #define XX_T_TYPE_MIXED 336
+#define XX_T_TYPE_FALSE 337
 
 #define XX_T_NAMESPACE 350
 #define XX_T_CLASS 351

--- a/parser/zephir.lemon
+++ b/parser/zephir.lemon
@@ -702,6 +702,14 @@ xx_method_return_type_item(R) ::= THIS . {
 	}
 }
 
+xx_method_return_type_item(R) ::= FALSE . {
+	{
+		zval type;
+		xx_ret_type(&type, XX_T_TYPE_FALSE);
+		xx_ret_return_type_item(&R, &type, NULL, 0, 0, status->scanner_state);
+	}
+}
+
 xx_method_return_type_item(R) ::= xx_parameter_type(T) NOT . {
 	xx_ret_return_type_item(&R, &T, NULL, 1, 0, status->scanner_state);
 }
@@ -948,6 +956,10 @@ xx_parameter_type(R) ::= TYPE_RESOURCE . {
 
 xx_parameter_type(R) ::= TYPE_MIXED . {
 	xx_ret_type(&R, XX_TYPE_MIXED);
+}
+
+xx_parameter_type(R) ::= TYPE_FALSE . {
+	xx_ret_type(&R, XX_TYPE_FALSE);
 }
 
 xx_parameter_type(R) ::= TYPE_OBJECT . {

--- a/tests/functions/return-types/false.phpt
+++ b/tests/functions/return-types/false.phpt
@@ -1,0 +1,175 @@
+--TEST--
+Function definition with `false` return type
+--SKIPIF--
+<?php include(__DIR__ . '/../../skipif.inc'); ?>
+--FILE--
+<?php
+$code =<<<ZEP
+function singleReturn() -> false { return false; }
+
+function unionReturn() -> int | false { return 1; }
+ZEP;
+
+$ir = zephir_parse_file($code, '(eval code)');
+var_dump($ir);
+?>
+--EXPECT--
+array(2) {
+  [0]=>
+  array(7) {
+    ["type"]=>
+    string(8) "function"
+    ["name"]=>
+    string(12) "singleReturn"
+    ["statements"]=>
+    array(1) {
+      [0]=>
+      array(5) {
+        ["type"]=>
+        string(6) "return"
+        ["expr"]=>
+        array(5) {
+          ["type"]=>
+          string(4) "bool"
+          ["value"]=>
+          string(5) "false"
+          ["file"]=>
+          string(11) "(eval code)"
+          ["line"]=>
+          int(1)
+          ["char"]=>
+          int(49)
+        }
+        ["file"]=>
+        string(11) "(eval code)"
+        ["line"]=>
+        int(1)
+        ["char"]=>
+        int(51)
+      }
+    }
+    ["return-type"]=>
+    array(6) {
+      ["type"]=>
+      string(11) "return-type"
+      ["list"]=>
+      array(1) {
+        [0]=>
+        array(6) {
+          ["type"]=>
+          string(21) "return-type-parameter"
+          ["data-type"]=>
+          string(5) "false"
+          ["mandatory"]=>
+          int(0)
+          ["file"]=>
+          string(11) "(eval code)"
+          ["line"]=>
+          int(1)
+          ["char"]=>
+          int(35)
+        }
+      }
+      ["void"]=>
+      int(0)
+      ["file"]=>
+      string(11) "(eval code)"
+      ["line"]=>
+      int(1)
+      ["char"]=>
+      int(35)
+    }
+    ["file"]=>
+    string(11) "(eval code)"
+    ["line"]=>
+    int(3)
+    ["char"]=>
+    int(8)
+  }
+  [1]=>
+  array(7) {
+    ["type"]=>
+    string(8) "function"
+    ["name"]=>
+    string(11) "unionReturn"
+    ["statements"]=>
+    array(1) {
+      [0]=>
+      array(5) {
+        ["type"]=>
+        string(6) "return"
+        ["expr"]=>
+        array(5) {
+          ["type"]=>
+          string(3) "int"
+          ["value"]=>
+          string(1) "1"
+          ["file"]=>
+          string(11) "(eval code)"
+          ["line"]=>
+          int(3)
+          ["char"]=>
+          int(49)
+        }
+        ["file"]=>
+        string(11) "(eval code)"
+        ["line"]=>
+        int(3)
+        ["char"]=>
+        int(51)
+      }
+    }
+    ["return-type"]=>
+    array(6) {
+      ["type"]=>
+      string(11) "return-type"
+      ["list"]=>
+      array(2) {
+        [0]=>
+        array(6) {
+          ["type"]=>
+          string(21) "return-type-parameter"
+          ["data-type"]=>
+          string(3) "int"
+          ["mandatory"]=>
+          int(0)
+          ["file"]=>
+          string(11) "(eval code)"
+          ["line"]=>
+          int(3)
+          ["char"]=>
+          int(31)
+        }
+        [1]=>
+        array(6) {
+          ["type"]=>
+          string(21) "return-type-parameter"
+          ["data-type"]=>
+          string(5) "false"
+          ["mandatory"]=>
+          int(0)
+          ["file"]=>
+          string(11) "(eval code)"
+          ["line"]=>
+          int(3)
+          ["char"]=>
+          int(39)
+        }
+      }
+      ["void"]=>
+      int(0)
+      ["file"]=>
+      string(11) "(eval code)"
+      ["line"]=>
+      int(3)
+      ["char"]=>
+      int(39)
+    }
+    ["file"]=>
+    string(11) "(eval code)"
+    ["line"]=>
+    int(3)
+    ["char"]=>
+    int(8)
+  }
+}

--- a/tests/functions/return-types/float.phpt
+++ b/tests/functions/return-types/float.phpt
@@ -1,0 +1,60 @@
+--TEST--
+Function definition with `float` return type
+--SKIPIF--
+<?php include(__DIR__ . '/../../skipif.inc'); ?>
+--FILE--
+<?php
+$code =<<<ZEP
+function test() -> float { }
+ZEP;
+
+$ir = zephir_parse_file($code, '(eval code)');
+var_dump($ir);
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  array(6) {
+    ["type"]=>
+    string(8) "function"
+    ["name"]=>
+    string(4) "test"
+    ["return-type"]=>
+    array(6) {
+      ["type"]=>
+      string(11) "return-type"
+      ["list"]=>
+      array(1) {
+        [0]=>
+        array(6) {
+          ["type"]=>
+          string(21) "return-type-parameter"
+          ["data-type"]=>
+          string(6) "double"
+          ["mandatory"]=>
+          int(0)
+          ["file"]=>
+          string(11) "(eval code)"
+          ["line"]=>
+          int(1)
+          ["char"]=>
+          int(27)
+        }
+      }
+      ["void"]=>
+      int(0)
+      ["file"]=>
+      string(11) "(eval code)"
+      ["line"]=>
+      int(1)
+      ["char"]=>
+      int(27)
+    }
+    ["file"]=>
+    string(11) "(eval code)"
+    ["line"]=>
+    int(1)
+    ["char"]=>
+    int(9)
+  }
+}

--- a/tests/functions/return-types/int.phpt
+++ b/tests/functions/return-types/int.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Function definition with mandatory return type
+Function definition with `int` return type
 --SKIPIF--
 <?php include(__DIR__ . '/../../skipif.inc'); ?>
 --FILE--

--- a/tests/functions/return-types/mixed.phpt
+++ b/tests/functions/return-types/mixed.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Function definition with void
+Function definition with `mixed` return type
 --SKIPIF--
 <?php include(__DIR__ . '/../../skipif.inc'); ?>
 --FILE--


### PR DESCRIPTION
Hello!

* Type: new feature

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/php-zephir-parser/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Thanks
