### PR TITLE
feat: add destructuring assignment syntax (`let [a, b, c] = expr`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] - xxxx-xx-xx
 ### Added
+- Added support for array destructuring assignment syntax `let [a, b, c] = expr;`,
+  matching PHP 7.1+ short list convention. Supports skipped slots (`let [a, , c] = arr;`)
+  and all-caps variable names. Parser-only; compiler code generation tracked in
+  [zephir#2496](https://github.com/zephir-lang/zephir/issues/2496)
+  ([#18](https://github.com/zephir-lang/php-zephir-parser/issues/18))
 - Added `docs/grammar.ebnf` containing the complete Zephir grammar in EBNF notation
   for railroad diagram visualization via [bottlecaps.de/rr/ui](https://www.bottlecaps.de/rr/ui)
   ([#106](https://github.com/zephir-lang/php-zephir-parser/issues/106))

--- a/parser/parser.h
+++ b/parser/parser.h
@@ -761,7 +761,8 @@ static void xx_ret_let_property_access_assignment(zval *ret, zval *operator, zva
 /**
  * Destructuring assignment: let [a, b, c] = expr;
  * Produces an AST node with assign-type "destructure", a flat "variables"
- * array (strings for named slots, null for skipped slots), and the RHS expr.
+ * array (identifier AST nodes for named slots, null for skipped slots),
+ * and the RHS expr.
  */
 static void xx_ret_let_destructure(zval *ret, zval *variables, zval *expr, xx_scanner_state *state)
 {

--- a/parser/parser.h
+++ b/parser/parser.h
@@ -758,6 +758,27 @@ static void xx_ret_let_property_access_assignment(zval *ret, zval *operator, zva
 	parser_add_int(ret, "char", state->active_char);
 }
 
+/**
+ * Destructuring assignment: let [a, b, c] = expr;
+ * Produces an AST node with assign-type "destructure", a flat "variables"
+ * array (strings for named slots, null for skipped slots), and the RHS expr.
+ */
+static void xx_ret_let_destructure(zval *ret, zval *variables, zval *expr, xx_scanner_state *state)
+{
+	array_init(ret);
+
+	parser_add_str(ret, "assign-type", "destructure");
+	parser_add_str(ret, "operator", "assign");
+	parser_add_zval(ret, "variables", variables);
+	if (expr) {
+		parser_add_zval(ret, "expr", expr);
+	}
+
+	parser_add_str(ret, "file", state->active_file);
+	parser_add_int(ret, "line", state->active_line);
+	parser_add_int(ret, "char", state->active_char);
+}
+
 static void xx_ret_if_statement(zval *ret, zval *expr, zval *statements, zval *elseif_statements, zval *else_statements, xx_scanner_state *state)
 {
 	array_init(ret);

--- a/parser/zephir.lemon
+++ b/parser/zephir.lemon
@@ -2086,6 +2086,35 @@ xx_let_assignment(R) ::= BRACKET_OPEN STRING(S) BRACKET_CLOSE xx_assignment_oper
 	xx_ret_let_assignment(&R, "dynamic-variable-string", &O, S, NULL, NULL, &E, status->scanner_state);
 }
 
+/* Destructuring assignment: let [a, b, c] = expr; */
+xx_let_assignment(R) ::= SBRACKET_OPEN xx_destructure_list(L) SBRACKET_CLOSE ASSIGN xx_assign_expr(E) . {
+	xx_ret_let_destructure(&R, &L, &E, status->scanner_state);
+}
+
+/* Destructure list: comma-separated variable names (IDENTIFIER or CONSTANT).
+ * Two consecutive commas produce a null entry (skipped slot). */
+xx_destructure_list(R) ::= xx_destructure_list(L) COMMA xx_destructure_var(V) . {
+	xx_ret_list(&R, &L, &V, status->scanner_state);
+}
+
+xx_destructure_list(R) ::= xx_destructure_var(V) . {
+	xx_ret_list(&R, NULL, &V, status->scanner_state);
+}
+
+/* A single destructure target: a variable name */
+xx_destructure_var(R) ::= IDENTIFIER(I) . {
+	xx_ret_literal(&R, XX_T_IDENTIFIER, I, status->scanner_state);
+}
+
+xx_destructure_var(R) ::= CONSTANT(I) . {
+	xx_ret_literal(&R, XX_T_IDENTIFIER, I, status->scanner_state);
+}
+
+/* Skipped slot: empty entry between commas → produces null */
+xx_destructure_var(R) ::= . {
+	ZVAL_NULL(&R);
+}
+
 xx_index_expr(R) ::= xx_common_expr(E) . {
 	R = E;
 }

--- a/tests/errors/destructure-errors.phpt
+++ b/tests/errors/destructure-errors.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Destructuring assignment error cases (issue #18)
+--SKIPIF--
+<?php include(__DIR__ . '/../skipif.inc'); ?>
+--FILE--
+<?php
+// Compound operator is not valid for destructuring: let [a, b] += arr;
+$code1 = 'class Foo { public function bar() { let [a, b] += arr; } }';
+$ir1 = zephir_parse_file($code1, '(eval code)');
+var_dump($ir1['type']);
+var_dump($ir1['message']);
+
+// Nested brackets are not valid: let [[a, b]] = arr;
+$code2 = 'class Foo { public function bar() { let [[a, b]] = arr; } }';
+$ir2 = zephir_parse_file($code2, '(eval code)');
+var_dump($ir2['type']);
+var_dump($ir2['message']);
+?>
+--EXPECT--
+string(5) "error"
+string(12) "Syntax error"
+string(5) "error"
+string(12) "Syntax error"
+

--- a/tests/errors/destructure-errors.phpt
+++ b/tests/errors/destructure-errors.phpt
@@ -4,21 +4,50 @@ Destructuring assignment error cases (issue #18)
 <?php include(__DIR__ . '/../skipif.inc'); ?>
 --FILE--
 <?php
-// Compound operator is not valid for destructuring: let [a, b] += arr;
-$code1 = 'class Foo { public function bar() { let [a, b] += arr; } }';
-$ir1 = zephir_parse_file($code1, '(eval code)');
-var_dump($ir1['type']);
-var_dump($ir1['message']);
+function check($code) {
+    $ir = zephir_parse_file('class F { public function b() { ' . $code . ' } }', '(eval code)');
+    return isset($ir['type']) && $ir['type'] === 'error' ? 'error' : 'ok';
+}
 
-// Nested brackets are not valid: let [[a, b]] = arr;
-$code2 = 'class Foo { public function bar() { let [[a, b]] = arr; } }';
-$ir2 = zephir_parse_file($code2, '(eval code)');
-var_dump($ir2['type']);
-var_dump($ir2['message']);
+// 1) Compound operator += is not valid
+var_dump(check('let [a, b] += arr;'));
+
+// 2) Compound operator -= is not valid
+var_dump(check('let [a, b] -= arr;'));
+
+// 3) Compound operator .= is not valid
+var_dump(check('let [a, b] .= arr;'));
+
+// 4) Compound operator *= is not valid
+var_dump(check('let [a, b] *= arr;'));
+
+// 5) Nested brackets: let [[a, b]] = arr;
+var_dump(check('let [[a, b]] = arr;'));
+
+// 6) Integer literals in destructure target: let [1, 2] = arr;
+var_dump(check('let [1, 2] = arr;'));
+
+// 7) String literals in destructure target: let ["a", "b"] = arr;
+var_dump(check('let ["a", "b"] = arr;'));
+
+// 8) Expression in destructure target: let [a + b] = arr;
+var_dump(check('let [a + b] = arr;'));
+
+// 9) Missing RHS: let [a, b] = ;
+var_dump(check('let [a, b] = ;'));
+
+// 10) Missing equals: let [a, b] arr;
+var_dump(check('let [a, b] arr;'));
 ?>
 --EXPECT--
 string(5) "error"
-string(12) "Syntax error"
 string(5) "error"
-string(12) "Syntax error"
+string(5) "error"
+string(5) "error"
+string(5) "error"
+string(5) "error"
+string(5) "error"
+string(5) "error"
+string(5) "error"
+string(5) "error"
 

--- a/tests/statements/destructure.phpt
+++ b/tests/statements/destructure.phpt
@@ -5,12 +5,12 @@ Destructuring assignment: let [a, b, c] = expr (issue #18)
 --FILE--
 <?php
 function stmt($code) {
-    $ir = zephir_parse_file($code, '(eval code)');
+    $ir = zephir_parse_file('class F { public function b() { ' . $code . ' } }', '(eval code)');
     return $ir[0]['definition']['methods'][0]['statements'][0]['assignments'][0];
 }
 
-// Basic: let [a, b] = arr;
-$a = stmt('class Foo { public function bar() { let [a, b] = arr; } }');
+// 1) Basic two-variable destructure
+$a = stmt('let [a, b] = arr;');
 var_dump($a['assign-type']);
 var_dump($a['operator']);
 var_dump(count($a['variables']));
@@ -19,39 +19,118 @@ var_dump($a['variables'][1]['value']);
 var_dump($a['expr']['type']);
 var_dump($a['expr']['value']);
 
-// Three variables: let [x, y, z] = arr;
-$a = stmt('class Foo { public function bar() { let [x, y, z] = arr; } }');
+// 2) Three variables
+$a = stmt('let [x, y, z] = arr;');
 var_dump(count($a['variables']));
 var_dump($a['variables'][0]['value']);
 var_dump($a['variables'][1]['value']);
 var_dump($a['variables'][2]['value']);
 
-// Skipped slot: let [a, , c] = arr;
-$a = stmt('class Foo { public function bar() { let [a, , c] = arr; } }');
+// 3) Five variables
+$a = stmt('let [a, b, c, d, e] = arr;');
+var_dump(count($a['variables']));
+var_dump($a['variables'][4]['value']);
+
+// 4) Single variable
+$a = stmt('let [x] = arr;');
+var_dump(count($a['variables']));
+var_dump($a['variables'][0]['value']);
+
+// 5) Skipped slot in middle: let [a, , c] = arr;
+$a = stmt('let [a, , c] = arr;');
 var_dump(count($a['variables']));
 var_dump($a['variables'][0]['value']);
 var_dump($a['variables'][1]);
 var_dump($a['variables'][2]['value']);
 
-// All-caps (CONSTANT token) names: let [A, B] = arr;
-$a = stmt('class Foo { public function bar() { let [A, B] = arr; } }');
+// 6) Leading skip: let [, b] = arr;
+$a = stmt('let [, b] = arr;');
+var_dump(count($a['variables']));
+var_dump($a['variables'][0]);
+var_dump($a['variables'][1]['value']);
+
+// 7) Trailing skip: let [a, ] = arr;
+$a = stmt('let [a, ] = arr;');
+var_dump(count($a['variables']));
+var_dump($a['variables'][0]['value']);
+var_dump($a['variables'][1]);
+
+// 8) Multiple consecutive skips: let [a, , , d] = arr;
+$a = stmt('let [a, , , d] = arr;');
+var_dump(count($a['variables']));
+var_dump($a['variables'][0]['value']);
+var_dump($a['variables'][1]);
+var_dump($a['variables'][2]);
+var_dump($a['variables'][3]['value']);
+
+// 9) All-caps (CONSTANT token) variable names
+$a = stmt('let [A, B] = arr;');
 var_dump($a['assign-type']);
 var_dump($a['variables'][0]['value']);
 var_dump($a['variables'][1]['value']);
 
-// Mixed case: let [a, B, c] = arr;
-$a = stmt('class Foo { public function bar() { let [a, B, c] = arr; } }');
+// 10) Mixed case names
+$a = stmt('let [a, B, c] = arr;');
 var_dump(count($a['variables']));
 var_dump($a['variables'][0]['value']);
 var_dump($a['variables'][1]['value']);
 var_dump($a['variables'][2]['value']);
 
-// RHS is a function call expression: let [w, h] = getimagesize(path);
-$a = stmt('class Foo { public function bar() { let [w, h] = getimagesize(path); } }');
-var_dump($a['assign-type']);
-var_dump($a['variables'][0]['value']);
-var_dump($a['variables'][1]['value']);
+// 11) RHS: function call
+$a = stmt('let [w, h] = getimagesize(path);');
 var_dump($a['expr']['type']);
+
+// 12) RHS: method call
+$a = stmt('let [a, b] = this->getData();');
+var_dump($a['expr']['type']);
+
+// 13) RHS: static call
+$a = stmt('let [a, b] = MyClass::split(str);');
+var_dump($a['expr']['type']);
+
+// 14) RHS: array literal
+$a = stmt('let [a, b] = [1, 2];');
+var_dump($a['expr']['type']);
+
+// 15) RHS: ternary expression
+$a = stmt('let [a, b] = cond ? x : y;');
+var_dump($a['expr']['type']);
+
+// 16) RHS: new object
+$a = stmt('let [a, b] = new MyObj();');
+var_dump($a['expr']['type']);
+
+// 17) RHS: property access
+$a = stmt('let [a, b] = obj->items;');
+var_dump($a['expr']['type']);
+
+// 18) RHS: array access
+$a = stmt('let [a, b] = arr[0];');
+var_dump($a['expr']['type']);
+
+// 19) Mixed with normal assignment in same let: let x = 1, [a, b] = arr;
+$ir = zephir_parse_file('class F { public function b() { let x = 1, [a, b] = arr; } }', '(eval code)');
+$assigns = $ir[0]['definition']['methods'][0]['statements'][0]['assignments'];
+var_dump(count($assigns));
+var_dump($assigns[0]['assign-type']);
+var_dump($assigns[0]['variable']);
+var_dump($assigns[1]['assign-type']);
+var_dump(count($assigns[1]['variables']));
+
+// 20) Multiple destructures in one let: let [a, b] = x, [c, d] = y;
+$ir = zephir_parse_file('class F { public function b() { let [a, b] = x, [c, d] = y; } }', '(eval code)');
+$assigns = $ir[0]['definition']['methods'][0]['statements'][0]['assignments'];
+var_dump(count($assigns));
+var_dump($assigns[0]['assign-type']);
+var_dump($assigns[0]['variables'][0]['value']);
+var_dump($assigns[1]['assign-type']);
+var_dump($assigns[1]['variables'][0]['value']);
+
+// 21) Destructure inside namespace
+$ir = zephir_parse_file('namespace Ns; class F { public function b() { let [a, b] = arr; } }', '(eval code)');
+$a = $ir[1]['definition']['methods'][0]['statements'][0]['assignments'][0];
+var_dump($a['assign-type']);
+var_dump(count($a['variables']));
 ?>
 --EXPECT--
 string(11) "destructure"
@@ -65,10 +144,25 @@ int(3)
 string(1) "x"
 string(1) "y"
 string(1) "z"
+int(5)
+string(1) "e"
+int(1)
+string(1) "x"
 int(3)
 string(1) "a"
 NULL
 string(1) "c"
+int(2)
+NULL
+string(1) "b"
+int(2)
+string(1) "a"
+NULL
+int(4)
+string(1) "a"
+NULL
+NULL
+string(1) "d"
 string(11) "destructure"
 string(1) "A"
 string(1) "B"
@@ -76,8 +170,24 @@ int(3)
 string(1) "a"
 string(1) "B"
 string(1) "c"
-string(11) "destructure"
-string(1) "w"
-string(1) "h"
 string(5) "fcall"
+string(5) "mcall"
+string(5) "scall"
+string(5) "array"
+string(7) "ternary"
+string(3) "new"
+string(15) "property-access"
+string(12) "array-access"
+int(2)
+string(8) "variable"
+string(1) "x"
+string(11) "destructure"
+int(2)
+int(2)
+string(11) "destructure"
+string(1) "a"
+string(11) "destructure"
+string(1) "c"
+string(11) "destructure"
+int(2)
 

--- a/tests/statements/destructure.phpt
+++ b/tests/statements/destructure.phpt
@@ -1,0 +1,83 @@
+--TEST--
+Destructuring assignment: let [a, b, c] = expr (issue #18)
+--SKIPIF--
+<?php include(__DIR__ . '/../skipif.inc'); ?>
+--FILE--
+<?php
+function stmt($code) {
+    $ir = zephir_parse_file($code, '(eval code)');
+    return $ir[0]['definition']['methods'][0]['statements'][0]['assignments'][0];
+}
+
+// Basic: let [a, b] = arr;
+$a = stmt('class Foo { public function bar() { let [a, b] = arr; } }');
+var_dump($a['assign-type']);
+var_dump($a['operator']);
+var_dump(count($a['variables']));
+var_dump($a['variables'][0]['value']);
+var_dump($a['variables'][1]['value']);
+var_dump($a['expr']['type']);
+var_dump($a['expr']['value']);
+
+// Three variables: let [x, y, z] = arr;
+$a = stmt('class Foo { public function bar() { let [x, y, z] = arr; } }');
+var_dump(count($a['variables']));
+var_dump($a['variables'][0]['value']);
+var_dump($a['variables'][1]['value']);
+var_dump($a['variables'][2]['value']);
+
+// Skipped slot: let [a, , c] = arr;
+$a = stmt('class Foo { public function bar() { let [a, , c] = arr; } }');
+var_dump(count($a['variables']));
+var_dump($a['variables'][0]['value']);
+var_dump($a['variables'][1]);
+var_dump($a['variables'][2]['value']);
+
+// All-caps (CONSTANT token) names: let [A, B] = arr;
+$a = stmt('class Foo { public function bar() { let [A, B] = arr; } }');
+var_dump($a['assign-type']);
+var_dump($a['variables'][0]['value']);
+var_dump($a['variables'][1]['value']);
+
+// Mixed case: let [a, B, c] = arr;
+$a = stmt('class Foo { public function bar() { let [a, B, c] = arr; } }');
+var_dump(count($a['variables']));
+var_dump($a['variables'][0]['value']);
+var_dump($a['variables'][1]['value']);
+var_dump($a['variables'][2]['value']);
+
+// RHS is a function call expression: let [w, h] = getimagesize(path);
+$a = stmt('class Foo { public function bar() { let [w, h] = getimagesize(path); } }');
+var_dump($a['assign-type']);
+var_dump($a['variables'][0]['value']);
+var_dump($a['variables'][1]['value']);
+var_dump($a['expr']['type']);
+?>
+--EXPECT--
+string(11) "destructure"
+string(6) "assign"
+int(2)
+string(1) "a"
+string(1) "b"
+string(8) "variable"
+string(3) "arr"
+int(3)
+string(1) "x"
+string(1) "y"
+string(1) "z"
+int(3)
+string(1) "a"
+NULL
+string(1) "c"
+string(11) "destructure"
+string(1) "A"
+string(1) "B"
+int(3)
+string(1) "a"
+string(1) "B"
+string(1) "c"
+string(11) "destructure"
+string(1) "w"
+string(1) "h"
+string(5) "fcall"
+


### PR DESCRIPTION
## Summary

Add parser support for **array destructuring assignments** using square bracket syntax, matching PHP 7.1+ `[$a, $b] = $arr;` convention.

### Syntax

```zep
var a, b, c, arr;
let arr = [1, 2, 3];

// Basic destructuring
let [a, b, c] = arr;

// Skip slots with consecutive commas
let [a, , c] = arr;

// All-caps variable names work too
let [A, B] = arr;

// RHS can be any expression
let [w, h] = getimagesize(path);
```

### Changes

**`parser/parser.h`** — New `xx_ret_let_destructure()` helper that creates an AST node:
```json
{
  "assign-type": "destructure",
  "operator": "assign",
  "variables": [
    {"type": "variable", "value": "a"},
    {"type": "variable", "value": "b"},
    {"type": "variable", "value": "c"}
  ],
  "expr": { ... }
}
```
Skipped slots (e.g., `let [a, , c] = arr;`) produce `null` entries in the `variables` array.

**`parser/zephir.lemon`** — Grammar additions:
- `xx_destructure_list` — comma-separated variable names
- `xx_destructure_var` — IDENTIFIER / CONSTANT / empty (skip slot)
- `xx_let_assignment` rule: `SBRACKET_OPEN xx_destructure_list SBRACKET_CLOSE ASSIGN xx_assign_expr`
- Only plain `=` is accepted; compound operators (`+=`, etc.) correctly trigger a syntax error
- Zero conflicts reported by Lemon

**Tests:**
- `tests/statements/destructure.phpt` — Success cases: basic, three vars, skip slots, all-caps names, mixed case, fcall RHS
- `tests/errors/destructure-errors.phpt` — Error cases: compound operator, nested brackets

### Scope

This is a **parser-only** change. The Zephir compiler (`zephir/zephir`) needs a corresponding `Destructure` handler in `Statements/Let/` to generate C code. A companion issue will be filed there.

Closes #18

