### PR TITLE
Fix build from sources

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -67,7 +67,7 @@ if test "$PHP_ZEPHIR_PARSER" = "yes"; then
   ifdef([PHP_INSTALL_HEADERS],
     [PHP_INSTALL_HEADERS([ext/zephir_parser], $PHP_ZEPHIR_PARSER_HEADERS)])
 
-  PHP_ADD_MAKEFILE_FRAGMENT([parser.mk])
+  PHP_ADD_MAKEFILE_FRAGMENT([$ext_srcdir/parser.mk])
 
   dnl Create directories because PECL can't
   if test ! -d parser; then

--- a/parser.mk
+++ b/parser.mk
@@ -47,7 +47,7 @@ $(srcdir)/parser/parser.c: $(srcdir)/parser/zephir.c $(srcdir)/parser/base.c
 	echo "#line 1 \"$(top_srcdir)/parser/base.c\"" >> $@
 	cat $(top_srcdir)/parser/base.c >> $@
 
-$(srcdir)/parser/zephir.c: $(srcdir)/parser/zephir.lemon $(srcdir)/parser/lemon patch-libtool
+$(srcdir)/parser/zephir.c: $(srcdir)/parser/zephir.lemon $(srcdir)/parser/lemon
 	$(top_srcdir)/parser/lemon $<
 
 # For more see: https://stackoverflow.com/q/49476206

--- a/parser.mk
+++ b/parser.mk
@@ -39,7 +39,7 @@ $(srcdir)/parser/scanner.c: $(srcdir)/parser/scanner.re
 	$(RE2C) $(RE2C_FLAGS) -d --no-generation-date -o $@ $<
 
 $(srcdir)/parser/lemon: $(srcdir)/parser/lemon.c
-	$(CC) $< -o $@
+	$(CC) -ansi $< -o $@
 
 $(srcdir)/parser/parser.c: $(srcdir)/parser/zephir.c $(srcdir)/parser/base.c
 	@echo "#include <php.h>" > $@


### PR DESCRIPTION
Context: transition from pecl archive (deprecated) to git sources

Using the pecl archive, lemon is not needed
Using git sources, Lemon needs to be built

## First commit: forces C90 standard, and avoid build failure

```
./parser/lemon.c: In function 'actioncmp':
./parser/lemon.c:354:12: warning: old-style function definition [-Wold-style-definition]
  354 | static int actioncmp(ap1,ap2)
      |            ^~~~~~~~~
./parser/lemon.c: In function 'Action_sort':
./parser/lemon.c:370:16: warning: old-style function definition [-Wold-style-definition]
  370 | struct action *Action_sort(ap)
      |                ^~~~~~~~~~~
./parser/lemon.c:372:1: error: number of arguments doesn't match prototype
  372 | {
      | ^
./parser/lemon.c:47:16: error: prototype declaration
   47 | struct action *Action_sort();
      |                ^~~~~~~~~~~
./parser/lemon.c:373:25: error: too many arguments to function 'msort'; expected 0, have 3
  373 |   ap = (struct action *)msort((char *)ap,(char **)&ap->next,actioncmp);
      |                         ^~~~~ ~~~~~~~~~~
./parser/lemon.c:43:7: note: declared here
   43 | char *msort();
      |       ^~~~~
...
```

## Second commit: remove "patch-libtool" dependency

As this file doesn't exists, on make call generate a new build
With this change "make" works as expected (and thus avoids a new build when running "make install" or "make test")

## Third commit: fix out of sources build

by setting the full path of the parser.mk file

Without this (empty Makefile.fragments)
`make[1]: *** No rule to make target '/dev/shm/BUILD/php-zephir-parser-2.5.0-build/php-zephir-parser-2.5.0/parser/parser.c', needed by 'parser/parser.lo'.  Stop.
`
